### PR TITLE
Fix: removed undefined segments (TT and AT)

### DIFF
--- a/src/caf/base/data_structures.py
+++ b/src/caf/base/data_structures.py
@@ -4,6 +4,7 @@ Module containing the data structures used in the CAF package.
 
 Currently this is only the DVector class, but this may be expanded in the future.
 """
+
 from __future__ import annotations
 
 # Built-Ins

--- a/src/caf/base/segmentation.py
+++ b/src/caf/base/segmentation.py
@@ -5,6 +5,7 @@ Module for handling segmentation objects.
 This imports the Segment class from caf.base.segments, and the SegmentsSuper
 enumeration from caf.base.segments. Both are used for building segmentations.
 """
+
 from __future__ import annotations
 
 # Built-Ins

--- a/src/caf/base/segments.py
+++ b/src/caf/base/segments.py
@@ -345,8 +345,6 @@ class SegmentsSuper(enum.Enum):
     SOC = "soc"
     SIC = "sic"
     CA = "ca"
-    TFN_AT = "tfn_at"
-    TFN_TT = "tfn_tt"
     USERCLASS = "userclass"
     ACCOMODATION_TYPE_H = "accom_h"
     ACCOMODATION_TYPE_HR = "accom_hr"

--- a/src/caf/base/segments.py
+++ b/src/caf/base/segments.py
@@ -343,7 +343,6 @@ class SegmentsSuper(enum.Enum):
     MODE = "m"
     GENDER = "g"
     SOC = "soc"
-    SIC = "sic"
     CA = "ca"
     USERCLASS = "userclass"
     ACCOMODATION_TYPE_H = "accom_h"
@@ -373,7 +372,6 @@ class SegmentsSuper(enum.Enum):
     UNI = "uni"
     DIRECTION = "direction"
     DIRECTION_OD = "direction_od"
-    UC = "uc"
 
     @classmethod
     def values(cls):

--- a/src/caf/base/zoning.py
+++ b/src/caf/base/zoning.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Holds the ZoningSystem Class which stores all information on different zoning systems."""
+
 # Allow class self hinting
 from __future__ import annotations
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ Other updates made by:
 File purpose:
 
 """
+
 # Built-Ins
 from pathlib import Path
 

--- a/tests/implicit_op_checks.py
+++ b/tests/implicit_op_checks.py
@@ -2,6 +2,7 @@
 """
 Example tests cases for implicit operations for Segmentation levels
 """
+
 from __future__ import annotations
 
 # Built-Ins

--- a/tests/test_dvec.py
+++ b/tests/test_dvec.py
@@ -14,6 +14,7 @@ aggregate
 translate
 
 """
+
 # Built-Ins
 from math import isclose
 

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Tests for the {} module"""
+
 # Built-Ins
 
 # Third Party

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -10,6 +10,7 @@ Other updates made by:
 File purpose:
 
 """
+
 # Built-Ins
 
 # Third Party

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -12,6 +12,7 @@ File purpose:
 """
 
 # Built-Ins
+import pathlib
 
 # Third Party
 import numpy as np
@@ -123,6 +124,12 @@ class TestSegmentsSuper:
         """Test all segments in :class:`SegmentsSuper` have YAML files."""
         for i in segments.SegmentsSuper:
             i.get_segment()
+
+    def test_extra_yaml(self):
+        """Test if any segment YAMLs aren't defined in :class:`SegmentsSuper`."""
+        directory = pathlib.Path(segments.__file__).parent / "segments"
+        for path in directory.glob("*.yml"):
+            segments.SegmentsSuper(path.stem)
 
 
 ##### Tests & Fixtures for `Segment` #####

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -118,6 +118,11 @@ class TestSegmentsSuper:
         with pytest.raises(ValueError, match=msg):
             segments.SegmentsSuper(name)
 
+    def test_get_all(self):
+        """Test all segments in :class:`SegmentsSuper` have YAML files."""
+        for i in segments.SegmentsSuper:
+            i.get_segment()
+
 
 ##### Tests & Fixtures for `Segment` #####
 

--- a/tests/test_zoning.py
+++ b/tests/test_zoning.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Tests for the `ZoningSystem` class."""
+
 # Built-Ins
 import dataclasses
 import string


### PR DESCRIPTION
# Changes

Removed traveller and area type segments from enum because they don't have any segment YAMLs defining them and they aren't used as segments anywhere.
- Area types is defined as a zoning system.
- Traveller types is a segmentation not a single segment.
- SIC removed because SIC_1, SIC_2... are used instead
- UC removed because USERCLASS is used instead
- Added tests to check if any `SegmentsSuper` values don't have YAML files and if any YAML files exist which aren't defined in `SegmentsSuper`

## Issues

- Closes #50

# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases) - No
- [x] Has documentation (including user guide) been updated - No
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt` - No
- [ ] Code linting, tests and other workflows pass
